### PR TITLE
Rackspace UK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,23 @@ In this example we only have `prod`, but you could have `staging`, etc.
 Remember that your Rackspace **API key** is private. If you are commiting your Gruntfile 
 to a public repository, you probably want to store it in a separate local_config.json file.
 
+For Rackspace UK users an additional configuration parameter `authUrl` is required to use the correct CDN url for UK accounts.
+
+```javascript
+cloudfiles: {
+  prod: {
+    ...
+    'authUrl': 'lon.identity.api.rackspacecloud.com',
+    ...
+  }
+}
+```
+
 ## Changelog
+
+### 0.0.4
+
+* Added support for Rackspace UK cloudfile accounts
 
 ### 0.0.3
 

--- a/tasks/cloudfiles.js
+++ b/tasks/cloudfiles.js
@@ -33,8 +33,8 @@ module.exports = function(grunt) {
     };
 
     // Optional config parameter authUrl - Used to overwrite the authUrl as defined by pkgcloud
-    if(this.data.hasOwnProperty("authUrl")){
-      clientConfig.authUrl = this.data.authUrl;
+    if(config.hasOwnProperty("authUrl")){
+      clientConfig.authUrl = config.authUrl;
     }
 
     client = cf.storage.createClient(clientConfig);

--- a/tasks/cloudfiles.js
+++ b/tasks/cloudfiles.js
@@ -26,11 +26,18 @@ module.exports = function(grunt) {
 
     config = this.data;
 
-    client = cf.storage.createClient({
+    var clientConfig = {
       'provider': 'rackspace',
       'username': config.user,
       'apiKey': config.key
-    })
+    };
+
+    // Optional config parameter authUrl - Used to overwrite the authUrl as defined by pkgcloud
+    if(this.data.hasOwnProperty("authUrl")){
+      clientConfig.authUrl = this.data.authUrl;
+    }
+
+    client = cf.storage.createClient(clientConfig);
 
     var cfActivity = [];
 


### PR DESCRIPTION
Added support for Rackspace UK customers.

When using my account name and API key I get upload errors

```
Thomas-Weltons-MacBook-Pro:ShakeYourMoneyMaker thomaswelton$ grunt cloudfiles
Running "cloudfiles:prod" (cloudfiles) task

Uploading into mentosmoneymakerlocal
>> Error: Invalid URI "/mentosmoneymakerlocal/somefolder/assets/stylesheets/compiled/template.css"

/Users/thomaswelton/Sites/ShakeYourMoneyMaker/node_modules/grunt-bower-task/node_modules/bower/node_modules/tmp/lib/tmp.js:219
    throw err;
          ^
TypeError: Cannot call method 'request' of undefined
    at Request.start (/Users/thomaswelton/Sites/ShakeYourMoneyMaker/node_modules/grunt-cloudfiles/node_modules/pkgcloud/node_modules/request/index.js:582:30)
    at Request.write (/Users/thomaswelton/Sites/ShakeYourMoneyMaker/node_modules/grunt-cloudfiles/node_modules/pkgcloud/node_modules/request/index.js:1144:28)
    at ondata (stream.js:38:26)
    at EventEmitter.emit (events.js:96:17)
    at Client.request.buffer.emit (/Users/thomaswelton/Sites/ShakeYourMoneyMaker/node_modules/grunt-cloudfiles/node_modules/pkgcloud/lib/pkgcloud/core/base/client.js:181:49)
    at BufferedStream.pipe.process.nextTick.self.size (/Users/thomaswelton/Sites/ShakeYourMoneyMaker/node_modules/grunt-cloudfiles/node_modules/pkgcloud/node_modules/morestreams/main.js:28:44)
    at Array.forEach (native)
    at BufferedStream.pipe.piped (/Users/thomaswelton/Sites/ShakeYourMoneyMaker/node_modules/grunt-cloudfiles/node_modules/pkgcloud/node_modules/morestreams/main.js:28:17)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```

This problem is mentioned here on the pkgcloud repo https://github.com/nodejitsu/pkgcloud/issues/72

I have made updates that allow us to overwrite the authUrl used by pkgcloud, and also updated the readme to reflect these changes.

There is now a new optional config parameter authUrl which can be specified in the Gruntfile which I am able to set to the correct value for use by UK customers, which is lon.identity.api.rackspacecloud.com
