### PR TITLE
Adding support for syncing based on MD5 hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-cloudfiles",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Grunt task to work with Rackspace Cloudfiles",
   "repository": {
     "type": "git",
@@ -32,8 +32,8 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "underscore.deferred": "~0.2.0",
-    "pkgcloud": "~0.6.7-1"
+    "async": "~0.2.9",
+    "pkgcloud": "~0.8.2"
   },
   "devDependencies": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
I wanted to open this PR even though it's not yet ready for merge. As part of a [pending PR](https://github.com/nodejitsu/pkgcloud/pull/161) I'm authoring for [`pkgcloud`](https://github.com/nodejitsu/pkgcloud) I've added robust CDN container support to the Rackspace storage provider. As part of this change, I've enabled `grunt-cloudfiles` to do the following when uploading:
1. Create and CDN enable the container, if not already created
2. Set the container to CDN enabled if it exists but is not CDN enabled
3. Upload the files based on MD5 hash, only uploading when not found in the container, or the MD5 hash is different.

As this PR depends on publishing the CDN changes to `pkgcloud` it's not yet ready to publish, but I wanted to start the dialog with you sooner.

I also took some liberty and moved to Async vs underscore deferred. I find the Async approach is more explicit and easy to follow/maintain, but I'm happy to negotiate on these points :)

Thanks!
