### PR TITLE
Purging files from the CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ cloudfiles: {
       'src': 'source/static/**/*',
       'dest': 'some/folder/',
       'stripcomponents': 1,
-      purge: {
-        emails: ['your@email.com'],
-        files: ['index.html']
+      'purge': {
+        'emails': ['your@email.com'],
+        'files': ['index.html']
       }
     }]
   }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ cloudfiles: {
       'container': 'name of your Cloud Files container',
       'src': 'source/static/**/*',
       'dest': 'some/folder/',
-      'stripcomponents': 1
+      'stripcomponents': 1,
+      purge: {
+        emails: ['your@email.com'],
+        files: ['index.html']
+      }
     }]
   }
 }
@@ -55,6 +59,9 @@ cloudfiles: {
 ```
 
 ## Changelog
+
+### 0.1.1
+* added an option to purge files after the upload
 
 ### 0.1.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-cloudfiles",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Grunt task to work with Rackspace Cloudfiles",
   "repository": {
     "type": "git",
@@ -29,6 +29,10 @@
     {
       "name": "Ken Perkins",
       "email": "ken.perkins@rackspace.com"
+    },
+    {
+      "name": "Kobi Meirson",
+      "email": "kobi@right.co.il"
     }
   ],
   "license": "MIT",

--- a/tasks/cloudfiles.js
+++ b/tasks/cloudfiles.js
@@ -63,7 +63,18 @@ module.exports = function(grunt) {
         }
         // good to go, just sync the files
         else {
-          syncFiles(upload, container, next);
+          syncFiles(upload, container, function purgeFiles() {
+            if (!upload.purge) {
+                return next();
+            }
+            grunt.log.subhead('Purging files from ' + upload.container);
+            async.forEachLimit(upload.purge.files, 10, function (fileName, n) {
+                grunt.log.writeln('Purging ' + fileName);
+                client.purgeFileFromCdn(container, fileName, upload.purge.emails || [], n)
+            }, function () {
+                next();
+            });
+          });
         }
       });
     }, function(err) {


### PR DESCRIPTION
After uploading files to a CDN container, you might want to purge one or so files (`index.html` is a great example for one, especially when you have a "Static website" container).
These changes help you do that.
