### PR TITLE
Added the destination to the ufile variable

### DIFF
--- a/tasks/cloudfiles.js
+++ b/tasks/cloudfiles.js
@@ -122,6 +122,10 @@ module.exports = function(grunt) {
       ufile = stripComponents(ufile, strip);
     }
 
+    if (dest) {
+        ufile = dest + ufile;
+    }
+
     hashFile(fileName, function (err, hash) {
       if (err) {
         return next(err);
@@ -135,7 +139,7 @@ module.exports = function(grunt) {
           grunt.log.writeln('Uploading ' + fileName + ' to ' + container.name + ' (NEW)');
           client.upload({
             container: container,
-            remote: dest + ufile,
+            remote: ufile,
             local: fileName,
             headers: headers
           }, function (err) {
@@ -146,7 +150,7 @@ module.exports = function(grunt) {
           grunt.log.writeln('Updating ' + fileName + ' to ' + container.name + ' (MD5 Diff)');
           client.upload({
             container: container,
-            remote: dest + ufile,
+            remote: ufile,
             local: fileName,
             headers: headers
           }, function (err) {


### PR DESCRIPTION
This fixes the issue where the call to client.getFile does not take into
account the destination when trying to compare the file being uploaded
to what already exists on the server. This fixes issue #19 on Github and
also solves the problem I was having where I wanted to add the files to
a subdirectory after having already added them to the root.

Apologies in advance for not attaching any tests.
