### PR TITLE
Added retry attempts to syncFiles.

### DIFF
--- a/tasks/cloudfiles.js
+++ b/tasks/cloudfiles.js
@@ -101,9 +101,31 @@ module.exports = function(grunt) {
 
     if (upload.dest === undefined) { upload.dest = '' }
 
+    var maxAttemptsPerFile = 5;
+
     async.forEachLimit(files, 10, function(file, next) {
+
+      var attempt = 1;
+
+      var onSyncFile = function(err) {
+        if(err) {
+            grunt.log.writeln('Error syncing file: ' + file + ' to ' + container.name + ', attempt: ' + attempt + '/' + maxAttemptsPerFile);
+
+            attempt++;
+
+            if(attempt < maxAttemptsPerFile) {
+                syncFile(file, container, upload.dest, upload.stripcomponents, upload.headers, onSyncFile);
+            } else {
+                next(err);
+            }
+
+        } else {
+            next();
+        }
+      }
+
       if (grunt.file.isFile(file)) {
-        syncFile(file, container, upload.dest, upload.stripcomponents, upload.headers, next);
+        syncFile(file, container, upload.dest, upload.stripcomponents, upload.headers, onSyncFile);
       }
       else {
         next();


### PR DESCRIPTION
Hey, I found I was getting errors when uploading large sets of files (10k+), which would cause the script to abort with error.

I've added a retry flow, to re-attempt the file for a maximum number of attempts.  From what i've seen, the next successive attempt usually succeeds. 
